### PR TITLE
Update README.md: update guidance for `MISSING_APIS_IN_DEFAULT_TAG` and `NOT_LATEST_API_VERSION_IN_DEFAULT_TAG`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ To solve this warning, you should make sure manager plane swagger located in res
 Level: ERROR
 
 The [default][AutoRest tags] API version tag (as seen in the `Basic information` section in the [AutoRest configuration file][AutoRest config] (the README file)) should contain all API paths.
-The API path \`${0}\` is not present in any OpenAPI `.json` files enumerated in the list of paths included in the default tag, as seen in the relevant `Tag:` section in the AutoRest configuration file (the README file).
+The API path \`${0}\` is not present in any OpenAPI `.json` files enumerated in the list of paths included in the default tag, as seen in the [relevant `Tag:` section][AutoRest tags] in the AutoRest configuration file (the README file).
 
 To fix this error include an OpenAPI `.json` file path in the list of the default API version tag paths (in the [relevant `Tag:` section][AutoRest tags]) that includes the missing API path.
 
-**WHEN THIS ERROR CAN BE SUPPRESSED**: If the missing API path is deprecated then you can suppress this error by following [this guidance](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process).
+**WHEN THIS ERROR CAN BE SUPPRESSED**: If the missing API path is deprecated then you can suppress this error.  Follow [this suppresion guidace](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process).
  
 For an example detailed analysis of an occurrence of such error, see [this GitHub comment](https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585095669).
 
@@ -142,10 +142,10 @@ For an example detailed analysis of an occurrence of such error, see [this GitHu
 
 Level: ERROR
 
-The [default][AutoRest tags] API version tag (as seen in the `Basic information` section in the [AutoRest configuration file][AutoRest config] (the README file)) does not contain the latest API version for given OpenAPI `.json` file. 
+The [default][AutoRest tags] API version tag (as seen in the `Basic information` section in the [AutoRest configuration file][AutoRest config] (the README file)) does not contain the latest API version of given OpenAPI `.json` file. 
 
 To fix this error, please make sure the `.json` file at the latest API version path is included in the list of paths for the default tag, in the [relevant `Tag:` section][AutoRest tags] in the AutoRest configuration file (the README file).
-Alternatively, change the default API version tag by editing the `Basic information` section.
+Alternatively, change the default API version tag to a valid one by editing the `Basic information` section.
 
 For an example detailed analysis of an occurrence of such error, see [this GitHub comment](https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585085436).
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The API path \`${0}\` is not present in any OpenAPI `.json` files enumerated in 
 
 To fix this error include an OpenAPI `.json` file path in the list of the default API version tag paths (in the [relevant `Tag:` section][AutoRest tags]) that includes the missing API path.
 
-**WHEN THIS ERROR CAN BE SUPPRESSED**: If the missing API path is deprecated then you can suppress this error.  Follow [this suppresion guidace](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process).
+**When this error can be suppressed**: If the missing API path is deprecated then you can suppress this error. Follow [this suppresion guide](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process).
  
 For an example detailed analysis of an occurrence of such error, see [this GitHub comment](https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585095669).
 

--- a/README.md
+++ b/README.md
@@ -129,17 +129,25 @@ To solve this warning, you should make sure manager plane swagger located in res
 
 Level: ERROR
 
-The default tag should contain all APIs. The API path \`${0}\` is not in the default tag. Please make sure the missing API swaggers are in the default tag.
+The default API version tag (as seen in the `Basic information` section in the AutoRest configuration file (the README file)) should contain all API paths.
+The API path \`${0}\` is not present in any OpenAPI `.json` files enumerated in the list of paths included in the default tag, as seen in the relevant `Tag:` section in the AutoRest configuration file (the README file).
 
-To fix this error. You should add the missing API swaggers to the default tag. If the missing API swaggers are deprecated, in this case this error could be ignored.
+To fix this error include an OpenAPI `.json` file path in the list of the default API version tag paths that includes the missing API path.
+
+**WHEN THIS ERROR CAN BE SUPPRESSED**: If the missing API path is deprecated then you can suppress this error by following [this guidance](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process).
+ 
+For an example detailed analysis of an occurrence of such error, see [this GitHub comment](https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585095669).
 
 ### NOT_LATEST_API_VERSION_IN_DEFAULT_TAG
 
 Level: ERROR
 
-The default tag does not contains the latest API version. Please make sure the latest api version swaggers are in the default tag.
+The default API version tag (as seen in the `Basic information` section in the AutoRest configuration file (the README file)) does not contain the latest API version for given OpenAPI `.json` file. 
 
-To fix this error. You should add the latest API version swaggers to the default tag or change default tag to reference latest api version tag.
+To fix this error, please make sure the `.json` file at the latest API version path is included in the list of paths for the default tag, in the relevant `Tag:` section in the AutoRest configuration file (the README file).
+Alternatively, change the default API version tag by editing the `Basic information` section.
+
+For an example detailed analysis of an occurrence of such error, see [this GitHub comment](https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585085436).
 
 ### MULTIPLE_DEFAULT_TAGS
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ To solve this warning, you should make sure manager plane swagger located in res
 
 Level: ERROR
 
-The [default API version tag](https://azure.github.io/autorest/generate/#adding-tags-when-generating) (as seen in the `Basic information` section in the [AutoRest configuration file](http://azure.github.io/autorest/user/configuration.html) (the README file)) should contain all API paths.
+The [default][AutoRest tags] API version tag (as seen in the `Basic information` section in the [AutoRest configuration file][AutoRest config] (the README file)) should contain all API paths.
 The API path \`${0}\` is not present in any OpenAPI `.json` files enumerated in the list of paths included in the default tag, as seen in the relevant `Tag:` section in the AutoRest configuration file (the README file).
 
-To fix this error include an OpenAPI `.json` file path in the list of the default API version tag paths that includes the missing API path.
+To fix this error include an OpenAPI `.json` file path in the list of the default API version tag paths (in the [relevant `Tag:` section][AutoRest tags]) that includes the missing API path.
 
 **WHEN THIS ERROR CAN BE SUPPRESSED**: If the missing API path is deprecated then you can suppress this error by following [this guidance](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/85/Swagger-Suppression-Process).
  
@@ -142,9 +142,9 @@ For an example detailed analysis of an occurrence of such error, see [this GitHu
 
 Level: ERROR
 
-The [default API version tag](https://azure.github.io/autorest/generate/#adding-tags-when-generating) (as seen in the `Basic information` section in the [AutoRest configuration file](http://azure.github.io/autorest/user/configuration.html) (the README file)) does not contain the latest API version for given OpenAPI `.json` file. 
+The [default][AutoRest tags] API version tag (as seen in the `Basic information` section in the [AutoRest configuration file][AutoRest config] (the README file)) does not contain the latest API version for given OpenAPI `.json` file. 
 
-To fix this error, please make sure the `.json` file at the latest API version path is included in the list of paths for the default tag, in the relevant `Tag:` section in the AutoRest configuration file (the README file).
+To fix this error, please make sure the `.json` file at the latest API version path is included in the list of paths for the default tag, in the [relevant `Tag:` section][AutoRest tags] in the AutoRest configuration file (the README file).
 Alternatively, change the default API version tag by editing the `Basic information` section.
 
 For an example detailed analysis of an occurrence of such error, see [this GitHub comment](https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585085436).
@@ -178,3 +178,6 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+[AutoRest config]: http://azure.github.io/autorest/user/configuration.html
+[AutoRest tags]: https://azure.github.io/autorest/generate/#adding-tags-when-generating

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ To solve this warning, you should make sure manager plane swagger located in res
 
 Level: ERROR
 
-The default API version tag (as seen in the `Basic information` section in the AutoRest configuration file (the README file)) should contain all API paths.
+The [default API version tag](https://azure.github.io/autorest/generate/#adding-tags-when-generating) (as seen in the `Basic information` section in the [AutoRest configuration file](http://azure.github.io/autorest/user/configuration.html) (the README file)) should contain all API paths.
 The API path \`${0}\` is not present in any OpenAPI `.json` files enumerated in the list of paths included in the default tag, as seen in the relevant `Tag:` section in the AutoRest configuration file (the README file).
 
 To fix this error include an OpenAPI `.json` file path in the list of the default API version tag paths that includes the missing API path.
@@ -142,7 +142,7 @@ For an example detailed analysis of an occurrence of such error, see [this GitHu
 
 Level: ERROR
 
-The default API version tag (as seen in the `Basic information` section in the AutoRest configuration file (the README file)) does not contain the latest API version for given OpenAPI `.json` file. 
+The [default API version tag](https://azure.github.io/autorest/generate/#adding-tags-when-generating) (as seen in the `Basic information` section in the [AutoRest configuration file](http://azure.github.io/autorest/user/configuration.html) (the README file)) does not contain the latest API version for given OpenAPI `.json` file. 
 
 To fix this error, please make sure the `.json` file at the latest API version path is included in the list of paths for the default tag, in the relevant `Tag:` section in the AutoRest configuration file (the README file).
 Alternatively, change the default API version tag by editing the `Basic information` section.


### PR DESCRIPTION
[Relevant Teams thread](https://teams.microsoft.com/l/message/19:0351f5f9404446e4b4fd4eaf2c27448d@thread.skype/1686243089290?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1686243089290&teamName=Azure%20SDK&channelName=API%20Spec%20Review&createdTime=1686243089290) that motivated me to make this update.

The updated doc points to two new GitHub comments I added:
- https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585085436
- https://github.com/Azure/azure-rest-api-specs/pull/23941#issuecomment-1585095669