### PR TITLE
Update azure-pipelines.yml: fix ubuntu image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
           reportDirectory: '$(System.DefaultWorkingDirectory)/**/coverage'
   - job: Build
     pool:
-      vmImage: 'Ubuntu 22.04'
+      vmImage: 'ubuntu-22.04'
     steps:
       - task: Npm@1
         displayName: 'npm pack'


### PR DESCRIPTION
The current one, modified by:
- https://github.com/Azure/avocado/pull/123

Has [failed with](https://dev.azure.com/azure-sdk/public/_build/results?buildId=2840283&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774):

```
##[warning]An image label with the label Ubuntu 22.04 does not exist.
,##[error]The remote provider was unable to process the request.
Pool: [Azure Pipelines](https://dev.azure.com/azure-sdk/29ec6040-b234-4e31-b139-33dc4287b756/_settings/agentqueues?poolId=&queueId=57)
Image: Ubuntu 22.04
Started: Today at 1:01 PM
Duration: 3m 10s

Job preparation parameters
8 queue time variables used
```

The one I am proposing now should work per this doc:
- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources


