### PR TITLE
Restore export of getDefaultTag()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+- Restore exported API `getDefaultTag()`, accidentally removed in 0.8.12
+
 ## 0.9.0
 
 - Breaking Change: Requires Node 18 or higher

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/avocado",
-  "version": "0.8.14",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/avocado",
-      "version": "0.8.14",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@azure/openapi-markdown": "^0.9.4",
@@ -45,6 +45,9 @@
         "tslint-immutable": "^6.0.1",
         "tslint-plugin-prettier": "^2.0.1",
         "typescript": "3.5.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/avocado",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A validator of OpenAPI configurations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
   getSwaggerFiles,
   SwaggerFileList,
   IService,
+  getDefaultTag,
   getTagsToSwaggerFilesMapping,
   getLatestTag,
   sortByApiVersion,


### PR DESCRIPTION
Removed in this PR, I suspect accidentally:

https://github.com/Azure/avocado/pull/93/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L203

Called from code in repo `openapi-alps`.