### PR TITLE
multiple-api-versions-as-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.2
+
+- Change rule MULTIPLE_API_VERSION from warning to error level.
+
 ## 0.9.1
 
 - Restore exported API `getDefaultTag()`, accidentally removed in 0.8.12

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ C-->A
 
 ### MULTIPLE_API_VERSION
 
-Level: WARNING
+Level: ERROR
 
-The default tag should contain only one API version swagger.
+The default tag should contain only one API version.
 
-To solve this warning , you should copy the swaggers of old version into the current version folder.
+To solve this error, you should add a new consistent version for all resource types within your service and copy the specs into the current version folder.
 
 ### INVALID_FILE_LOCATION
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/avocado",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A validator of OpenAPI configurations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -693,7 +693,7 @@ const validateReadMeFile = (readMePath: string): asyncIt.AsyncIterableEx<err.Err
         readMeUrl: readMePath,
         tag: getDefaultTag(m.markDown),
         path: readMePath,
-        level: 'Warning',
+        level: 'Error',
       }
     }
   })

--- a/src/test/avocado-test.ts
+++ b/src/test/avocado-test.ts
@@ -292,7 +292,7 @@ describe('avocado', () => {
     const expected = [
       {
         code: 'MULTIPLE_API_VERSION',
-        level: 'Warning',
+        level: 'Error',
         message: 'The default tag contains multiple API versions swaggers.',
         tag: 'package-2019-01-01',
         readMeUrl: path.resolve('src/test/multi_api_version/specification/testRP/readme.md'),


### PR DESCRIPTION
We should not allow multiple api version within default tag as it's violating the version uniform guideline, if there's any suppression requirement for this, @JeffreyRichter and I can help with the approval.