### PR TITLE
Temporarily revert brace-expansion 5.0.9 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,9 +1596,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Temporarily reverts #340, restoring `brace-expansion` 5.0.8 in `package-lock.json`.

This intentionally restores a version with a known security vulnerability because the organization cannot adopt 5.0.9 for a few more days. The 5.0.9 update should be reapplied as soon as that temporary constraint is removed.

## Validation

- Confirmed the revert changes only `package-lock.json`
- Confirmed the resolved package is `brace-expansion-5.0.8.tgz`