### PR TITLE
Fix regression: restore source branch checkout after suppression filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.12.1
 
 - Fix regression introduced in 0.12.0 where newly added specs incorrectly raised `MISSING_README` errors. Suppression filtering for Azure DevOps validation left the working directory checked out on the target branch instead of the source branch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix regression introduced in 0.12.0 where newly added specs incorrectly raised `MISSING_README` errors. Suppression filtering for Azure DevOps validation left the working directory checked out on the target branch instead of the source branch.
+
 ## 0.12.0
 
 - Add path suppression support to Azure DevOps validation using suppressions.yaml with tool names: `SwaggerAvocado` and `SwaggerAll`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure/avocado",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure/avocado",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@azure/openapi-markdown": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/avocado",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A validator of OpenAPI configurations",
   "type": "module",
   "main": "dist/index.js",

--- a/src/avocado-suppressions.ts
+++ b/src/avocado-suppressions.ts
@@ -41,5 +41,10 @@ export const excludeSuppressedPaths = async (
     suppressedPaths.add(suppressedPath)
   }
 
+  // Restore the working directory to the source branch. Callers expect the working
+  // directory to reflect the source branch content (e.g. to find readme.md files for
+  // newly added specs) after suppression filtering completes.
+  await pr.checkout(pr.sourceBranch)
+
   return fileChanges.map((item) => item.path).filter((item) => !suppressedPaths.has(item))
 }

--- a/src/test/dev-ops-test.ts
+++ b/src/test/dev-ops-test.ts
@@ -12,7 +12,14 @@ import { avocado, cli, devOps, git } from '../index.js'
 import * as tmpDir from './tmp-dir.js'
 
 type MockAction =
-  'remove readme' | 'modify json' | 'add file' | 'update readme' | 'update .github' | 'remove file' | 'use suppression'
+  | 'remove readme'
+  | 'modify json'
+  | 'add file'
+  | 'update readme'
+  | 'update .github'
+  | 'remove file'
+  | 'use suppression'
+  | 'add new spec'
 
 /**
  * Create Azure DevOps environment for testing.
@@ -174,6 +181,30 @@ input-file:
     await pfs.unlink(path.join(resourceManagerFolder, 'file1.json'))
   }
 
+  if (action.includes('add new spec')) {
+    // brand new RP folder, including its readme.md, that does not exist on the target branch.
+    const newResourceProviderFolder = path.join(specification, 'newRP')
+    const newResourceManagerFolder = path.join(newResourceProviderFolder, 'resource-manager')
+    await pfs.mkdir(newResourceProviderFolder)
+    await pfs.mkdir(newResourceManagerFolder)
+    await pfs.writeFile(
+      path.join(newResourceManagerFolder, 'readme.md'),
+      `
+# New RP
+
+> see https://aka.ms/autorest
+
+### Tag: package-2020-07-01
+
+\`\`\` yaml $(tag)=='package-2020-07-01'
+input-file:
+- $(this-folder)/new.json
+\`\`\`
+`,
+    )
+    await pfs.writeFile(path.join(newResourceManagerFolder, 'new.json'), `{"foo":"bar"}`)
+  }
+
   await pfs.writeFile(path.join(remote, 'license'), 'MIT')
   await gitRemote({ add: ['.'] })
   await gitRemote({
@@ -278,6 +309,12 @@ describe('Azure DevOps', () => {
 
   it('filters suppressed paths in Azure DevOps validation', async () => {
     const cfg = await createDevOpsEnv('devops-pr-suppression', ['add file', 'modify json', 'use suppression'])
+    const errors = await avocado(cfg).toArray()
+    assert.deepStrictEqual(errors, [])
+  })
+
+  it('does not raise MISSING_README for a brand new spec added by the PR', async () => {
+    const cfg = await createDevOpsEnv('devops-pr-add-new-spec', ['add new spec'])
     const errors = await avocado(cfg).toArray()
     assert.deepStrictEqual(errors, [])
   })


### PR DESCRIPTION
## Summary
Fixes #357.

`excludeSuppressedPaths` (added in #350) checked out `targetBranch` to check suppressions for deleted files, but never restored `sourceBranch` afterward. The subsequent `readme.md` lookup in `avocadoForDevOps` then ran against target-branch content, so brand-new specs (whose `readme.md` only exists on the source branch) incorrectly raised `MISSING_README`.

## Fix
Restore the working directory to `sourceBranch` at the end of `excludeSuppressedPaths`, so callers see source-branch content as before PR #350.

## Testing
- Added a regression test (`does not raise MISSING_README for a brand new spec added by the PR`) that adds a brand new RP folder + readme.md only on the source branch. Verified it fails without the fix and passes with it.
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npx vitest run src/test/dev-ops-test.ts src/test/suppressions-test.ts` (18 tests passed)